### PR TITLE
Bump swagger-ui to ~2.2.10

### DIFF
--- a/blueprints/ember-swagger-ui/index.js
+++ b/blueprints/ember-swagger-ui/index.js
@@ -6,7 +6,7 @@ module.exports = {
 
   beforeInstall: function(options) {
     return this.addBowerPackagesToProject([
-      { name: 'swagger-ui', target: '2.2.6' },
+      { name: 'swagger-ui', target: '~2.2.10' },
       { name: 'jquery-migrate', target: '1.2.1' }
     ]);
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "0.1.3"
   },
   "devDependencies": {
-    "swagger-ui": "2.2.6",
+    "swagger-ui": "~2.2.10",
     "jquery-migrate": "1.2.1",
     "blanket": "5e94fc30f2e694bb5c3718ddcbf60d467f4b4d26"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-swagger-ui",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "An ember-cli addon for adding swagger-ui to your ember app",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION


Fixes 
![image](https://cloud.githubusercontent.com/assets/5072452/22660742/999afc46-ec9a-11e6-899e-7f05a189a97e.png)

I can also enforce the `swagger-ui` version in my own `bower.json` but I figured it might be useful for others.

@rynam0  