### PR TITLE
remove ember-browserify

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The object takes any and all supported [swagger-ui 3.x configuration](https://gi
     // controllers/application.js
     
     import Controller from '@ember/controller';
-    import Swag from 'npm:swagger-ui-dist';
+    import Swag from 'swagger-ui';
 
     const {
       SwaggerUIBundle,

--- a/addon/components/swagger-ui.js
+++ b/addon/components/swagger-ui.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/swagger-ui';
-import Swag from 'npm:swagger-ui-dist';
+import Swag from 'swagger-ui';
 
 const { Component } = Ember;
 const { SwaggerUIBundle } = Swag;

--- a/app/components/swagger-ui.js
+++ b/app/components/swagger-ui.js
@@ -1,3 +1,1 @@
-import swag from 'npm:swagger-ui-dist';
-
 export { default } from 'ember-swagger-ui/components/swagger-ui';

--- a/blueprints/ember-swagger-ui/index.js
+++ b/blueprints/ember-swagger-ui/index.js
@@ -5,11 +5,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   beforeInstall: function(options) {
-    return this.addAddonToProject({
-      name: 'ember-browserify',
-      target: '^1.2.0'
-    }).then(() => {
-      return this.addPackageToProject('swagger-ui-dist', '^3.9.2');
-    });
+    return this.addPackageToProject('swagger-ui-dist', '^3.9.2');
   }
 };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     app.import('node_modules/swagger-ui-dist/swagger-ui.css');
+    app.import('node_modules/swagger-ui-dist/swagger-ui-bundle.js');
+    app.import('node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js');
+    app.import('vendor/shims/swagger-ui.js');
   },
 
   contentFor: function(type, config) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "3.0.0",
-    "ember-browserify": "^1.2.0",
     "ember-cli": "~2.15.1",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.0.0",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import Swag from 'npm:swagger-ui-dist';
+import Swag from 'swagger-ui';
 
 const {
   SwaggerUIBundle,

--- a/vendor/shims/swagger-ui.js
+++ b/vendor/shims/swagger-ui.js
@@ -1,0 +1,15 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    return {
+      'default': {
+        SwaggerUIBundle: self['SwaggerUIBundle'],
+        SwaggerUIStandalonePreset: self['SwaggerUIStandalonePreset']
+      },
+      __esModule: true,
+    };
+  }
+
+  define('swagger-ui', [], vendorModule);
+})();


### PR DESCRIPTION
ember-browserify is deprecated https://github.com/ef4/ember-browserify#deprecation-warning

Since swagger pushlishes a dist already, we don't need a secondary bundler step. This method is the fastest since it doesn't scan app code for imports, and it doesn't run a bundler like webpack.