### PR TITLE
add usePublic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ The object takes any and all supported [swagger-ui 3.x configuration](https://gi
     {{!-- application.hbs --}}
     {{swagger-ui config=swaggerConfig}}
 
+### Options
+
+    // ember-cli-build.js
+
+    let app = new EmberAddon(defaults, {
+      'ember-swagger-ui': {
+        // use public tree instead of vendor concat
+        usePublic: true
+      }
+    });
+
 
 ## ember-swagger-ui < 1.0.0 (Pre-releases)
 

--- a/package.json
+++ b/package.json
@@ -60,8 +60,11 @@
     "swagger"
   ],
   "dependencies": {
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^3.0.1",
     "ember-cli-babel": "^6.3.0",
-    "ember-cli-htmlbars": "^2.0.1"
+    "ember-cli-htmlbars": "^2.0.1",
+    "resolve": "^1.8.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
We're finding that the concat of the swagger vendor files is taking a long time. Using the files as-is in the public tree seems to eliminate that time spent.