### PR TITLE
bring the sourcemaps along when using public

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,10 @@ module.exports = {
     let absolutePath = resolve.sync('swagger-ui-dist', { basedir: this.project.root });
 
     trees.push(new Funnel(path.dirname(absolutePath), {
-      files: [
-        'swagger-ui.css',
-        'swagger-ui-bundle.js',
-        'swagger-ui-standalone-preset.js'
+      include: [
+        'swagger-ui.css*',
+        'swagger-ui-bundle.js*',
+        'swagger-ui-standalone-preset.js*'
       ],
       destDir: 'swagger-ui-dist',
       annotation: `Funnel ${this.name} treeForPublic`


### PR DESCRIPTION
This will avoid console warnings like

```
[WARN] (broccoli-uglify-sourcemap) "swagger-ui-bundle.js.map" referenced in "swagger-ui-dist/swagger-ui-bundle.js" could not be found
[WARN] (broccoli-uglify-sourcemap) "swagger-ui-standalone-preset.js.map" referenced in "swagger-ui-dist/swagger-ui-standalone-preset.js" could not be found
```