### PR TITLE
provide uglify settings to prevent double minify

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ module.exports = {
 
     let options = app.options['ember-swagger-ui'] || {};
 
-    if (!options.usePublic) {
+    if (options.usePublic) {
+      let uglify = app.options['ember-cli-uglify'] = app.options['ember-cli-uglify'] || {};
+      uglify.exclude = (uglify.exclude || []).concat('swagger-ui-dist/**');
+    } else {
       app.import('node_modules/swagger-ui-dist/swagger-ui.css');
       app.import('node_modules/swagger-ui-dist/swagger-ui-bundle.js');
       app.import('node_modules/swagger-ui-dist/swagger-ui-standalone-preset.js');

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "demoURL": "http://rynam0.github.io/ember-swagger-ui/"
+    "demoURL": "http://rynam0.github.io/ember-swagger-ui/",
+    "before": [
+      "ember-cli-uglify"
+    ]
   }
 }


### PR DESCRIPTION
Without this, uglify will run minification on the already minified files. This gives a speed increase when using the usePublic option.